### PR TITLE
Document zip creation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# taiyaki_webpage
+# Taiyaki Webpage
+
+After generating pages, you can create a distribution archive by running:
+
+```bash
+zip -r site.zip index.html works.html works css js images data
+```
+


### PR DESCRIPTION
## Summary
- document how to manually create `site.zip` in README

## Testing
- `git rm site.zip` (fails because file doesn't exist)


------
https://chatgpt.com/codex/tasks/task_e_6867acc366288332a93181a9b4290ed5